### PR TITLE
Cursor bugfix and graceful exit

### DIFF
--- a/FallingParticles/Program.cs
+++ b/FallingParticles/Program.cs
@@ -98,7 +98,7 @@ class Program
                 var direction = moveLeft ? -1 : 1;
                 paddlePosition += direction * 3 * paddle.Length / 4;
             }
-            else if (cki.Key.ToString().ToLower() == "q") {
+            else if (cki.Key == ConsoleKey.Q) {
                 Console.Clear();
                 Console.CursorVisible = true;
                 Environment.Exit(0);

--- a/FallingParticles/Program.cs
+++ b/FallingParticles/Program.cs
@@ -1,4 +1,4 @@
-﻿using FallingParticles;
+using FallingParticles;
 
 class Program
 {
@@ -90,13 +90,18 @@ class Program
     {
         if (Console.KeyAvailable)
         {
-            var key = Console.ReadKey(true);
-            var moveLeft = key.Key == ConsoleKey.LeftArrow && paddlePosition >= paddleMoveDistance;
-            var moveRight = key.Key == ConsoleKey.RightArrow && paddlePosition < Console.WindowWidth - paddle.Length;
+            var cki = Console.ReadKey(true);
+            var moveLeft = cki.Key == ConsoleKey.LeftArrow && paddlePosition >= paddleMoveDistance;
+            var moveRight = cki.Key == ConsoleKey.RightArrow && paddlePosition < Console.WindowWidth - paddle.Length;
             if (moveLeft || moveRight)
             {
                 var direction = moveLeft ? -1 : 1;
                 paddlePosition += direction * 3 * paddle.Length / 4;
+            }
+            else if (cki.Key.ToString().ToLower() == "q") {
+                Console.Clear();
+                Console.CursorVisible = true;
+                Environment.Exit(0);
             }
         }
     }


### PR DESCRIPTION
There is no way to end gracefully.
Starting the application from a console window and then closing it (keyboard interrupt signal) will mess up the cursor.

In short, this is happening.
The cursor indicator (blinking effect) is never re-enabled and the its position is never reset.

Hotkey is now introduced for graceful exit by pressing 'Q'.

Why this fix?
While debugging this app the cursor bug became a bit annoying.